### PR TITLE
PHP 7.4 - Fix deprecated array access

### DIFF
--- a/tcpdf/tcpdi_parser.php
+++ b/tcpdf/tcpdi_parser.php
@@ -722,11 +722,11 @@ class tcpdi_parser {
         $objtype = ''; // object type to be returned
         $objval = ''; // object value to be returned
         // skip initial white space chars: \x00 null (NUL), \x09 horizontal tab (HT), \x0A line feed (LF), \x0C form feed (FF), \x0D carriage return (CR), \x20 space (SP)
-        while (strspn($data{$offset}, "\x00\x09\x0a\x0c\x0d\x20") == 1) {
+        while (strspn($data[$offset], "\x00\x09\x0a\x0c\x0d\x20") == 1) {
             $offset++;
         }
         // get first char
-        $char = $data{$offset};
+        $char = $data[$offset];
         // get object type
         switch ($char) {
             case '%': { // \x25 PERCENT SIGN
@@ -757,10 +757,10 @@ class tcpdi_parser {
                 if ($char == '(') {
                     $open_bracket = 1;
                     while ($open_bracket > 0) {
-                        if (!isset($data{$strpos})) {
+                        if (!isset($data[$strpos])) {
                             break;
                         }
-                        $ch = $data{$strpos};
+                        $ch = $data[$strpos];
                         switch ($ch) {
                             case '\\': { // REVERSE SOLIDUS (5Ch) (Backslash)
                                 // skip next character
@@ -828,7 +828,7 @@ class tcpdi_parser {
                 break;
             }
             default: {
-                $frag = $data{$offset} . @$data{$offset+1} . @$data{$offset+2} . @$data{$offset+3};
+                $frag = $data[$offset] . @$data[$offset+1] . @$data[$offset+2] . @$data[$offset+3];
                 switch ($frag) {
                     case 'endo':
                         // indirect object
@@ -905,16 +905,16 @@ class tcpdi_parser {
         $dict = '';
         $offset += 2;
         do {
-            if ($data{$offset} == '>' && $data{$offset+1} == '>') {
+            if ($data[$offset] == '>' && $data[$offset+1] == '>') {
                 $i--;
                 $dict .= '>>';
                 $offset += 2;
-            } else if ($data{$offset} == '<' && $data{$offset+1} == '<') {
+            } else if ($data[$offset] == '<' && $data[$offset+1] == '<') {
                 $i++;
                 $dict .= '<<';
                 $offset += 2;
             } else {
-                $dict .= $data{$offset};
+                $dict .= $data[$offset];
                 $offset++;
             }
         } while ($i>0);


### PR DESCRIPTION
Accessing arrays with curlies `{}` is deprecated in PHP 7.4:

_[2020-08-07 13:22:54] php.INFO: Deprecated: Array and string offset access syntax with curly braces is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: Array and string offset access syntax with curly braces is deprecated at /var/www/html/vendor/myokyawhtun/pdfmerger/tcpdf/tcpdi_parser.php:831)"} []_